### PR TITLE
single-click link

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -194,6 +194,8 @@ export class Game implements ISerializable<SerializedGame> {
   public oxygenSilverCubeBonusMC: number = 0;
   public venusSilverCubeBonusMC: number = 0;
 
+  public clickedLinks: Array<string> = [];
+
   // Card-specific data
   // Mons Insurance promo corp
   public monsInsuranceOwner: PlayerId | undefined = undefined;
@@ -399,6 +401,7 @@ export class Game implements ISerializable<SerializedGame> {
       awards: this.awards,
       board: this.board.serialize(),
       claimedMilestones: serializeClaimedMilestones(this.claimedMilestones),
+      clickedLinks: this.clickedLinks,
       colonies: this.colonies,
       colonyDealer: this.colonyDealer,
       dealer: this.dealer.serialize(),

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -73,9 +73,11 @@ import {LunaProjectOffice} from './cards/moon/LunaProjectOffice';
 import { UnitedNationsMissionOne } from './cards/community/corporations/UnitedNationsMissionOne';
 
 export type PlayerId = string;
+export type Password = string;
 
 export class Player implements ISerializable<SerializedPlayer> {
   public readonly id: PlayerId;
+  public password?: Password | undefined;
   private usedUndo: boolean = false;
   private waitingFor?: PlayerInput;
   private waitingForCb?: () => void;
@@ -2051,6 +2053,7 @@ export class Player implements ISerializable<SerializedPlayer> {
   public serialize(): SerializedPlayer {
     const result: SerializedPlayer = {
       id: this.id,
+      password: this.password,
       corporationCard: this.corporationCard === undefined ? undefined : {
         name: this.corporationCard.name,
         resourceCount: this.corporationCard.resourceCount,

--- a/src/SerializedGame.ts
+++ b/src/SerializedGame.ts
@@ -23,6 +23,7 @@ export interface SerializedGame {
     awards: Array<IAward>;
     board: SerializedBoard;
     claimedMilestones: Array<SerializedClaimedMilestone>;
+    clickedLinks: Array<string>,
     clonedGamedId?: string;
     colonies: Array<SerializedColony>;
     colonyDealer: ColonyDealer | undefined;

--- a/src/SerializedPlayer.ts
+++ b/src/SerializedPlayer.ts
@@ -1,4 +1,4 @@
-import {PlayerId} from './Player';
+import {Password, PlayerId} from './Player';
 import {CardName} from './CardName';
 import {Color} from './Color';
 import {SerializedCard} from './SerializedCard';
@@ -38,6 +38,7 @@ export interface SerializedPlayer {
     name: string;
     needsToDraft: boolean | undefined;
     oceanBonus: number;
+    password?: Password | undefined;
     pickedCorporationCard: CardName | undefined;
     plantProduction: number;
     plants: number;

--- a/src/components/GameHome.ts
+++ b/src/components/GameHome.ts
@@ -79,9 +79,8 @@ export const GameHome = Vue.component('game-home', {
           <li v-for="(player, index) in (game === undefined ? [] : game.players)">
             <span class="turn-order">{{getTurnOrder(index)}}</span>
             <span :class="'color-square ' + getPlayerCubeColorClass(player.color)"></span>
-            <span class="player-name"><a :href="getHref(player.id)">{{player.name}}</a></span>
-            <Button title="copy" size="tiny" :onClick="_=>copyUrl(player.id)"/>
-            <span v-if="isPlayerUrlCopied(player.id)" class="copied-notice">Playable link for {{player.name}} copied to clipboard <span class="dismissed" @click="setCopiedIdToDefault" >dismiss</span></span>
+            <span v-if="player.id !== ''" class="player-name"><a :href="getHref(player.id)" :onClick="_=>copyUrl(player.id)">{{player.name}}</a></span>
+            <span v-else class="player-name">{{player.name}}</span>
           </li>
         </ul>
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,12 +51,21 @@ function processRequest(req: http.IncomingMessage, res: http.ServerResponse): vo
         } else {
           serveApp(req, res);
         }
+      } else if (req.url.startsWith('/player?id=')) {
+        // If this player id is called to the server, add to this game's clicked links.
+        const playerId: string = req.url.substring(
+          '/player?id='.length);
+        GameLoader.getInstance().getByPlayerId(playerId, (game) => {
+          if (!game?.clickedLinks.includes(playerId)) {
+            game?.clickedLinks.push(playerId);
+          }
+        });
+        serveApp(req, res);
       } else if (
         req.url === '/' ||
         req.url.startsWith('/new-game') ||
         req.url.startsWith('/solo') ||
         req.url.startsWith('/game?id=') ||
-        req.url.startsWith('/player?id=') ||
         req.url.startsWith('/the-end?id=') ||
         req.url.startsWith('/load') ||
         req.url.startsWith('/debug-ui') ||

--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -49,7 +49,7 @@ export class Server {
       phase: game.phase,
       players: game.getPlayers().map((player) => ({
         color: player.color,
-        id: player.id,
+        id: game.clickedLinks.includes(player.id) ? '' : player.id,
         name: player.name,
       })),
       gameOptions: getGameOptionsAsModel(game.gameOptions),


### PR DESCRIPTION
A single click link (work in progress)

How it work: server.ts registers first time a player id is opened and store that the playerId link has been clicked. ServerModel passes down to GameHomeModel the real playerId if it has not been clicked yet or empty string if it has been clicked. GameHome displays accordingly.

Problem: 
- GameHome is static. If two users open the page at the same time, they both will have access to the real player id no matter who click first.
- Serialization problem. It does not seem to serialize properly. If the server reset, it forgets which links were clicked.

Solution (still thinking about it):
- When server.ts registers the first click. It adds a password as a new property to player. And redirect the link to player?id=XXXX?password=XXXX.
- From now, anyone who wants to send request for player id without password, the server will not process it. 