### PR TITLE
enforce margin, add small cards back

### DIFF
--- a/src/components/Preferences.ts
+++ b/src/components/Preferences.ts
@@ -298,6 +298,12 @@ export const Preferences = Vue.component('preferences', {
                     </div>
                     <div class="preferences_panel_item">
                         <label class="form-switch">
+                            <input type="checkbox" v-on:change="updatePreferences" v-model="small_cards" />
+                            <i class="form-icon"></i> <span v-i18n>Smaller cards</span>
+                        </label>
+                    </div>
+                    <div class="preferences_panel_item">
+                        <label class="form-switch">
                             <input type="checkbox" v-on:change="updatePreferences" v-model="magnify_cards" />
                             <i class="form-icon"></i> <span v-i18n>Magnify cards on hover</span>
                         </label>

--- a/src/styles/turmoil.less
+++ b/src/styles/turmoil.less
@@ -227,6 +227,7 @@
     display: inline-block;
     width: 164px;
     height: 307px;
+    margin: 15px 10px 10px 0px;
     border: none;
     box-shadow: none;
     border-radius: 0px;


### PR DESCRIPTION
- add margin to <party> element
- add small card preference back, I think for unknown reasons, users can be stuck with large cards on Heroku.