### PR TITLE
Fix serialization for Random Turmoil

### DIFF
--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -797,6 +797,13 @@ export const CreateGameForm = Vue.component('create-game-form', {
                                     <span v-i18n>Board tiles</span>&nbsp;<a href="https://github.com/bafolts/terraforming-mars/wiki/Variants#randomize-board-tiles" class="tooltip" target="_blank">&#9432;</a>
                             </label>
 
+                            <div v-if="isRandomTurmoilEnabled()">
+                                <input type="checkbox" v-model="randomTurmoil" id="randomTurmoil-checkbox" v-on:change="randomTurmoilToggle()">
+                                <label for="randomTurmoil-checkbox">
+                                    <span v-i18n>Turmoil</span>&nbsp;<a href="https://www.notion.so/Variants-32b53050f10a4cfbaea117c34d4f3a03#db8ed5d103f14fc69ec3248ecddc1617" class="tooltip" target="_blank">&#9432;</a>
+                                </label>
+                            </div>
+
                             <div class="create-game-subsection-label" v-i18n>Filter</div>
 
                             <input type="checkbox" v-model="showCorporationList" id="customCorps-checkbox">

--- a/src/turmoil/SerializedTurmoil.ts
+++ b/src/turmoil/SerializedTurmoil.ts
@@ -1,7 +1,6 @@
-import {IGlobalEvent} from './globalEvents/IGlobalEvent';
 import {GlobalEventName} from './globalEvents/GlobalEventName';
 import {PartyName} from './parties/PartyName';
-import {SerializedGlobalEventDealer} from './globalEvents/SerializedGlobalEventDealer';
+import {SerializedGlobalEvent, SerializedGlobalEventDealer} from './globalEvents/SerializedGlobalEventDealer';
 import {SerializedPoliticalAgendasData} from './PoliticalAgendas';
 import {NeutralPlayer} from './Turmoil';
 import {PlayerId} from '../Player';
@@ -21,9 +20,10 @@ export interface SerializedTurmoil {
     parties: Array<SerializedParty>;
     playersInfluenceBonus: Array<[string, number]>;
     globalEventDealer: SerializedGlobalEventDealer;
-    distantGlobalEvent: GlobalEventName | undefined;
-    comingGlobalEvent: GlobalEventName | undefined;
+    distantGlobalEvent: SerializedGlobalEvent | undefined;
+    comingGlobalEvent: SerializedGlobalEvent | undefined;
     // TODO(kberg): By 2021-03-01, IGlobalEvent.
-    currentGlobalEvent?: IGlobalEvent | GlobalEventName;
+    currentGlobalEvent?: SerializedGlobalEvent | GlobalEventName;
     politicalAgendasData: SerializedPoliticalAgendasData | undefined;
+    globalEventDelegatesRandomisationDone: boolean;
 }

--- a/src/turmoil/globalEvents/GlobalEventDealer.ts
+++ b/src/turmoil/globalEvents/GlobalEventDealer.ts
@@ -37,7 +37,7 @@ import {SolarFlare} from './SolarFlare';
 import {VenusInfrastructure} from './VenusInfrastructure';
 import {CloudSocieties} from './CloudSocieties';
 import {MicrogravityHealthProblems} from './MicrogravityHealthProblems';
-import {SerializedGlobalEventDealer} from './SerializedGlobalEventDealer';
+import {SerializedGlobalEvent, SerializedGlobalEventDealer} from './SerializedGlobalEventDealer';
 import {ISerializable} from '../../ISerializable';
 import {FermiSolution} from './society/FermiSolution';
 import {OperationDaedalus} from './society/OperationDaedalus';
@@ -75,6 +75,7 @@ import {AtmosphericCompression} from './society/AtmosphericCompression';
 import {WoodlandInitiatives} from './society/WoodlandInitiatives';
 import {ThermalFusion} from './society/ThermalFusion';
 import {BloomingVale} from './society/BloomingVale';
+import {PartyName} from '../parties/PartyName';
 
 export interface IGlobalEventFactory<T> {
     globalEventName: GlobalEventName;
@@ -265,18 +266,28 @@ export class GlobalEventDealer implements ISerializable<SerializedGlobalEventDea
 
   public serialize(): SerializedGlobalEventDealer {
     return {
-      deck: this.globalEventsDeck.map((card) => card.name),
-      discarded: this.discardedGlobalEvents.map((card) => card.name),
+      deck: this.globalEventsDeck.map((card) => {
+        return {name: card.name, currentDelegate: card.currentDelegate, revealedDelegate: card.revealedDelegate};
+      }),
+      discarded: this.discardedGlobalEvents.map((card) => {
+        return {name: card.name, currentDelegate: card.currentDelegate, revealedDelegate: card.revealedDelegate};
+      }),
     };
   }
 
   public static deserialize(d: SerializedGlobalEventDealer): GlobalEventDealer {
-    const deck = d.deck.map((element: GlobalEventName) => {
-      return getGlobalEventByName(element)!;
+    const deck = d.deck.map((element: SerializedGlobalEvent) => {
+      const event = getGlobalEventByName(element.name!) as IGlobalEvent;
+      event.currentDelegate = element.currentDelegate as PartyName;
+      event.revealedDelegate = element.revealedDelegate as PartyName;
+      return event;
     });
 
-    const discardPile = d.discarded.map((element: GlobalEventName) => {
-      return getGlobalEventByName(element)!;
+    const discardPile = d.discarded.map((element: SerializedGlobalEvent) => {
+      const event = getGlobalEventByName(element.name!) as IGlobalEvent;
+      event.currentDelegate = element.currentDelegate as PartyName;
+      event.revealedDelegate = element.revealedDelegate as PartyName;
+      return event;
     });
     return new GlobalEventDealer(deck, discardPile);
   }

--- a/src/turmoil/globalEvents/SerializedGlobalEventDealer.ts
+++ b/src/turmoil/globalEvents/SerializedGlobalEventDealer.ts
@@ -1,6 +1,13 @@
+import {PartyName} from '../parties/PartyName';
 import {GlobalEventName} from './GlobalEventName';
 
 export interface SerializedGlobalEventDealer {
-  deck: Array<GlobalEventName>;
-  discarded: Array<GlobalEventName>;
+  deck: Array<SerializedGlobalEvent>;
+  discarded: Array<SerializedGlobalEvent>;
+}
+
+export interface SerializedGlobalEvent {
+  name: GlobalEventName | undefined;
+  currentDelegate: PartyName | undefined;
+  revealedDelegate: PartyName | undefined;
 }

--- a/tests/turmoil/Turmoil.spec.ts
+++ b/tests/turmoil/Turmoil.spec.ts
@@ -238,19 +238,18 @@ describe('Turmoil', function() {
       'playersInfluenceBonus': [],
       'globalEventDealer': {
         'deck': [
-          'Solar Flare',
-          'Spin-Off Products',
-          'Dry Deserts',
-          'Mud Slides',
-          'Productivity'],
-        'discarded': ['Pandemic']},
-      'distantGlobalEvent': 'Eco Sabotage',
-      'comingGlobalEvent': 'Celebrity Leaders',
+          {'name': 'Solar Flare', 'currentDelegate': 'Kelvinists', 'revealedDelegate': 'Unity'},
+          {'name': 'Spin-Off Products', 'currentDelegate': 'Scientists', 'revealedDelegate': 'Greens'},
+          {'name': 'Dry Deserts', 'currentDelegate': 'Unity', 'revealedDelegate': 'Reds'},
+          {'name': 'Mud Slides', 'currentDelegate': 'Greens', 'revealedDelegate': 'Kelvinists'},
+          {'name': 'Productivity', 'currentDelegate': 'Mars First', 'revealedDelegate': 'Scientists'}],
+        'discarded': [{'name': 'Pandemic', 'currentDelegate': 'Mars First', 'revealedDelegate': 'Greens'}]},
+      'distantGlobalEvent': {'name': 'Eco Sabotage', 'currentDelegate': 'Reds', 'revealedDelegate': 'Greens'},
+      'comingGlobalEvent': {'name': 'Celebrity Leaders', 'currentDelegate': 'Greens', 'revealedDelegate': 'Unity'},
       'politicalAgendasData': {'thisAgenda': {'bonusId': 'none', 'policyId': 'none'}},
     };
     const s: SerializedTurmoil = JSON.parse(JSON.stringify(json));
     const t = Turmoil.deserialize(s);
-
     expect(t.distantGlobalEvent!.name).eq('Eco Sabotage');
     expect(t.distantGlobalEvent!.revealedDelegate).eq('Greens');
     expect(t.comingGlobalEvent!.name).eq('Celebrity Leaders');


### PR DESCRIPTION
Done: Parties no longer re-randomize across server restarts

TODO: Top and bottom delegates for each global event change whenever server restarts
